### PR TITLE
Add progressive difficulty levels with pursuit behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,6 +17,36 @@ let baseSpeed = 0.8;
 let animationId;
 let gameState = 'running';
 
+// --- Configuración de niveles ---
+const levels = [
+    {
+        name: 'Nivel 1',
+        description: 'Pocos peces y ninguno te persigue.',
+        fishCount: 8,
+        baseSpeed: 0.65,
+        allowPursuit: false
+    },
+    {
+        name: 'Nivel 2',
+        description: 'Más peces y se mueven un poco más rápido.',
+        fishCount: 16,
+        baseSpeed: 0.85,
+        allowPursuit: false
+    },
+    {
+        name: 'Nivel 3',
+        description: 'Muchos peces y los grandes te persiguen.',
+        fishCount: 24,
+        baseSpeed: 1.0,
+        allowPursuit: true
+    }
+];
+
+let currentLevelIndex = 0;
+let levelAllowsPursuit = true;
+let levelTransitionTimeout = null;
+const playerInitialSize = 15;
+
 // --- Constantes para IA y Movimiento ---
 const visionRadius = 160;
 const fleeMargin = 1;
@@ -108,7 +138,7 @@ class Fish {
                 if (playerFish.size > this.size + fleeMargin) {
                     behavior = 'flee'; desiredAngle = angleToPlayer + Math.PI; currentTurnSpeed = turnSpeedFleePursue; currentSpeedMultiplier = speedMultiplierFlee;
                     if (debugAI && this.currentBehavior !== 'flee') console.log(`Fish ${this.color} Fleeing!`);
-                } else if (this.size > playerFish.size + pursueMargin) {
+                } else if (levelAllowsPursuit && this.size > playerFish.size + pursueMargin) {
                     behavior = 'pursue'; desiredAngle = angleToPlayer; currentTurnSpeed = turnSpeedFleePursue; currentSpeedMultiplier = speedMultiplierPursue;
                     if (debugAI && this.currentBehavior !== 'pursue') console.log(`Fish ${this.color} Pursuing!`);
                 }
@@ -178,6 +208,7 @@ function resizeCanvas() {
     canvasWidth = canvas.width;
     canvasHeight = canvas.height;
     console.log(`Canvas resized to: ${canvasWidth}x${canvasHeight} (bottomMargin: ${bottomMargin})`);
+    clearLevelTransitionTimer();
     initGame();
 }
 
@@ -190,28 +221,142 @@ function initGame() {
         if (canvas.width === 0) canvas.width = canvasWidth;
         if (canvas.height === 0 || canvas.height === window.innerHeight) canvas.height = canvasHeight; // Ajustar si no se aplicó el margen
     }
-    if (animationId) { cancelAnimationFrame(animationId); animationId = null; }
-    mouse.x = canvasWidth / 2; mouse.y = canvasHeight / 2;
-    gameState = 'running'; messageEl.textContent = ''; messageEl.style.display = 'none'; restartButton.style.display = 'none';
-    player = new PlayerFish(canvasWidth / 2, canvasHeight / 2, 15, 'orange');
-    player.setTarget(mouse.x, mouse.y);
+    currentLevelIndex = 0;
+    if (player) {
+        player = null;
+    }
+    startLevel(currentLevelIndex, { resetPlayer: true, resetPlayerSize: true });
+}
+
+function clearLevelTransitionTimer() {
+    if (levelTransitionTimeout) {
+        clearTimeout(levelTransitionTimeout);
+        levelTransitionTimeout = null;
+    }
+}
+
+function showTemporaryMessage(text, duration = 2000) {
+    messageEl.textContent = text;
+    messageEl.style.display = 'block';
+    restartButton.style.display = 'none';
+    if (duration > 0) {
+        setTimeout(() => {
+            if (gameState === 'running') {
+                messageEl.style.display = 'none';
+            }
+        }, duration);
+    }
+}
+
+function startLevel(levelIndex, { resetPlayer = false, resetPlayerSize = false } = {}) {
+    clearLevelTransitionTimer();
+    currentLevelIndex = Math.max(0, Math.min(levels.length - 1, levelIndex));
+    const levelConfig = levels[currentLevelIndex];
+
+    baseSpeed = levelConfig.baseSpeed;
+    levelAllowsPursuit = levelConfig.allowPursuit;
+    initialOtherFishCount = levelConfig.fishCount;
+
+    if (animationId) {
+        cancelAnimationFrame(animationId);
+        animationId = null;
+    }
+
+    mouse.x = canvasWidth / 2;
+    mouse.y = canvasHeight / 2;
+
+    if (!player || resetPlayer) {
+        const startingSize = resetPlayerSize ? playerInitialSize : (player ? player.size : playerInitialSize);
+        player = new PlayerFish(canvasWidth / 2, canvasHeight / 2, startingSize, 'orange');
+    } else {
+        player.x = canvasWidth / 2;
+        player.y = canvasHeight / 2;
+    }
+
+    if (resetPlayerSize && player) {
+        player.size = playerInitialSize;
+    }
+
+    if (player) {
+        player.setTarget(mouse.x, mouse.y);
+        player.angle = 0;
+    }
+
     otherFish = [];
     for (let i = 0; i < initialOtherFishCount; i++) {
         let size = Math.random() * 35 + 5;
         let x = Math.random() * (canvasWidth - size * 2) + size;
-        let y = Math.random() * (canvasHeight - size * 2) + size; // Usa canvasHeight global ya ajustado
+        let y = Math.random() * (canvasHeight - size * 2) + size;
         let color = getRandomColor();
         if (player && getDistance(x, y, player.x, player.y) > player.size + size + 60) {
             otherFish.push(new Fish(x, y, size, color));
-        } else { i--; }
+        } else {
+            i--;
+        }
     }
-    console.log(`Created ${otherFish.length} NPC fish.`);
-    bubbles = []; for (let i = 0; i < numBubbles; i++) { bubbles.push(new Bubble()); }
+    console.log(`Created ${otherFish.length} NPC fish for ${levelConfig.name}.`);
+
+    bubbles = [];
+    for (let i = 0; i < numBubbles; i++) {
+        bubbles.push(new Bubble());
+    }
     console.log(`Created ${bubbles.length} bubbles.`);
+
+    gameState = 'running';
+    messageEl.textContent = '';
+    messageEl.style.display = 'none';
+    restartButton.style.display = 'none';
+
     gameLoop();
+    showTemporaryMessage(`${levelConfig.name}: ${levelConfig.description}`);
 }
 
-function checkCollisions() { /* ... sin cambios ... */ if (!player) return; for (let i = otherFish.length - 1; i >= 0; i--) { const fish = otherFish[i]; const dist = getDistance(player.x, player.y, fish.x, fish.y); const collThr = (player.size + fish.size) * 0.7; if (dist < collThr) { const szDiff = 0.1; if (player.size > fish.size + szDiff) { player.grow(fish.size); otherFish.splice(i, 1); console.log(`Ate fish! Remaining: ${otherFish.length}`); if (otherFish.length === 0) { winGame(); return; } } else if (fish.size > player.size + szDiff) { gameOver(); return; } } } }
+function handleLevelClear() {
+    if (gameState !== 'running') return;
+    if (currentLevelIndex >= levels.length - 1) {
+        winGame();
+        return;
+    }
+
+    gameState = 'transition';
+    if (animationId) {
+        cancelAnimationFrame(animationId);
+        animationId = null;
+    }
+
+    messageEl.textContent = `¡${levels[currentLevelIndex].name} completado!`;
+    messageEl.style.display = 'block';
+    restartButton.style.display = 'none';
+
+    levelTransitionTimeout = setTimeout(() => {
+        messageEl.style.display = 'none';
+        startLevel(currentLevelIndex + 1);
+    }, 2000);
+}
+
+function checkCollisions() {
+    if (!player) return;
+    for (let i = otherFish.length - 1; i >= 0; i--) {
+        const fish = otherFish[i];
+        const dist = getDistance(player.x, player.y, fish.x, fish.y);
+        const collThr = (player.size + fish.size) * 0.7;
+        if (dist < collThr) {
+            const szDiff = 0.1;
+            if (player.size > fish.size + szDiff) {
+                player.grow(fish.size);
+                otherFish.splice(i, 1);
+                console.log(`Ate fish! Remaining: ${otherFish.length}`);
+                if (otherFish.length === 0) {
+                    handleLevelClear();
+                    return;
+                }
+            } else if (fish.size > player.size + szDiff) {
+                gameOver();
+                return;
+            }
+        }
+    }
+}
 
 function updateGame() {
     if (gameState !== 'running' || !player) return;
@@ -222,10 +367,10 @@ function updateGame() {
     checkCollisions();
 }
 
-function drawGame() { /* ... sin cambios en la estructura, pero usa canvasHeight ajustado ... */ if (!player) return; ctx.fillStyle = '#004070'; ctx.fillRect(0, 0, canvasWidth, canvasHeight); bubbles.forEach(b => b.draw()); otherFish.forEach(f => f.draw()); player.draw(); ctx.fillStyle = 'white'; ctx.font = '16px Arial'; ctx.fillText(`Tamaño: ${player.size.toFixed(1)}`, 10, 20); ctx.fillText(`Peces restantes: ${otherFish.length}`, 10, 40); }
+function drawGame() { /* ... sin cambios en la estructura, pero usa canvasHeight ajustado ... */ if (!player) return; ctx.fillStyle = '#004070'; ctx.fillRect(0, 0, canvasWidth, canvasHeight); bubbles.forEach(b => b.draw()); otherFish.forEach(f => f.draw()); player.draw(); ctx.fillStyle = 'white'; ctx.font = '16px Arial'; ctx.fillText(`Tamaño: ${player.size.toFixed(1)}`, 10, 20); ctx.fillText(`Peces restantes: ${otherFish.length}`, 10, 40); const levelInfo = levels[currentLevelIndex]; if (levelInfo) { ctx.fillText(`Nivel: ${levelInfo.name}`, 10, 60); } }
 function gameLoop() { /* ... sin cambios ... */ if (gameState !== 'running') { if (animationId) { cancelAnimationFrame(animationId); animationId = null; } return; } updateGame(); drawGame(); animationId = requestAnimationFrame(gameLoop); }
-function gameOver() { /* ... sin cambios ... */ console.log("Game Over!"); gameState = 'gameOver'; messageEl.textContent = '¡HAS SIDO COMIDO! GAME OVER'; messageEl.style.display = 'block'; restartButton.style.display = 'block'; if (animationId) cancelAnimationFrame(animationId); animationId = null; }
-function winGame() { /* ... sin cambios ... */ console.log("You Win!"); gameState = 'win'; messageEl.textContent = '¡FELICIDADES! ¡TE LOS COMISTE A TODOS!'; messageEl.style.display = 'block'; restartButton.style.display = 'block'; if (animationId) cancelAnimationFrame(animationId); animationId = null; }
+function gameOver() { /* ... sin cambios ... */ console.log("Game Over!"); clearLevelTransitionTimer(); gameState = 'gameOver'; messageEl.textContent = '¡HAS SIDO COMIDO! GAME OVER'; messageEl.style.display = 'block'; restartButton.style.display = 'block'; if (animationId) cancelAnimationFrame(animationId); animationId = null; }
+function winGame() { /* ... sin cambios ... */ console.log("You Win!"); clearLevelTransitionTimer(); gameState = 'win'; messageEl.textContent = '¡FELICIDADES! ¡TE LOS COMISTE A TODOS!'; messageEl.style.display = 'block'; restartButton.style.display = 'block'; if (animationId) cancelAnimationFrame(animationId); animationId = null; }
 
 // --- Event Listeners (sin cambios respecto a la versión anterior funcional) ---
 window.addEventListener('resize', () => { if (animationId) { cancelAnimationFrame(animationId); animationId = null; } resizeCanvas(); });


### PR DESCRIPTION
## Summary
- introduce a three-level progression configuration with unique fish counts, speeds, and pursuit rules
- add level transition handling, temporary messages, and HUD updates for level display
- ensure victory handling advances through levels and finalizes the game only after the last stage

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf43ab51a883319e686f8d5863bfd9